### PR TITLE
static-api/more-files

### DIFF
--- a/generators/static-api/README.md
+++ b/generators/static-api/README.md
@@ -1,0 +1,21 @@
+# static-api
+
+Generates files needed to package a "static API".
+
+## Usage
+
+Run generator from root of the API that needs a static representation.
+
+```
+$ yo springworks:static-api
+```
+
+## Result
+
+Files and directories in a structure similar to:
+
+```
+|_ bin
+|_ packages
+  |_ static-api
+```

--- a/generators/static-api/index.js
+++ b/generators/static-api/index.js
@@ -6,6 +6,7 @@ const module_dependencies = [
   '@springworks/static-api-server',
   'fixture-loader',
   'forever',
+  'swagger-md',
 ];
 
 module.exports = generators.Base.extend({
@@ -58,6 +59,11 @@ module.exports = generators.Base.extend({
 
     docs: function() {
       this.template('_README.md', 'packages/static-api/README.md');
+    },
+
+    binaries: function() {
+      this.template('bin/generate-docs.js', 'bin/generate-docs.js');
+      this.template('bin/generate-api-file.js', 'bin/generate-api-file.js');
     },
   },
 

--- a/generators/static-api/index.js
+++ b/generators/static-api/index.js
@@ -46,18 +46,18 @@ module.exports = generators.Base.extend({
   writing: {
 
     serverScripts: function() {
-      this.copy('index.js', 'index.js');
-      this.copy('run-server.js', 'run-server.js');
-      this.copy('bin/start-server.js', 'bin/start-server.js');
-      this.copy('bin/stop-server.js', 'bin/stop-server.js');
+      this.copy('index.js', 'packages/static-api/index.js');
+      this.copy('run-server.js', 'packages/static-api/run-server.js');
+      this.copy('bin/start-server.js', 'packages/static-api/bin/start-server.js');
+      this.copy('bin/stop-server.js', 'packages/static-api/bin/stop-server.js');
     },
 
     packageFile: function() {
-      this.template('_package.json', 'package.json');
+      this.template('_package.json', 'packages/static-api/package.json');
     },
 
     docs: function() {
-      this.template('_README.md', 'README.md');
+      this.template('_README.md', 'packages/static-api/README.md');
     },
   },
 

--- a/generators/static-api/templates/bin/generate-api-file.js
+++ b/generators/static-api/templates/bin/generate-api-file.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+/**
+ * Generates an api.json file based on js input.
+ *
+ * Not run through Babel, so needs to be Node 4 compliant.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const api_spec = require('../resources/api/index');
+const target_filename = path.join(__dirname, '..', 'packages', 'static-api', 'api.json');
+
+const api_as_json = JSON.stringify(api_spec, null, 2) + '\n';
+
+fs.writeFileSync(target_filename, api_as_json);

--- a/generators/static-api/templates/bin/generate-docs.js
+++ b/generators/static-api/templates/bin/generate-docs.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+/**
+ * Generates markdown documentation based on the Swagger specification.
+ *
+ * Not run through Babel, so needs to be Node 4 compliant.
+ */
+
+const fs = require('fs');
+const swagger_md = require('swagger-md');
+const api_spec = require('../resources/api/index');
+const static_api = require('../packages/static-api');
+
+const filename = 'API.md';
+
+function provideResponseExample(path, method) {
+  const full_path = api_spec.basePath + path;
+  try {
+    const json = static_api.provideFixtures().loadParsedJson(full_path, method);
+    const stringified = JSON.stringify(json, null, 2);
+    return [
+      '```json',
+      stringified,
+      '```',
+    ].join('\n');
+  }
+  catch (e) {
+    return 'N/A';
+  }
+}
+
+const markdown = swagger_md.default.convertToMarkdown(api_spec, provideResponseExample);
+
+fs.writeFileSync(filename, markdown);
+

--- a/test/static-api-test.js
+++ b/test/static-api-test.js
@@ -16,33 +16,36 @@ describe('test/static-api-test.js', () => {
   });
 
   it('should copy index file', () => {
-    assert.file('index.js');
+    assert.file('packages/static-api/index.js');
   });
 
   it('should copy README.md and set correct script names', () => {
-    assert.file('README.md');
-    assert.fileContent('README.md', /start-foo-app-static/);
-    assert.fileContent('README.md', /stop-foo-app-static/);
+    const readme_path = 'packages/static-api/README.md';
+    assert.file(readme_path);
+    assert.fileContent(readme_path, /start-foo-app-static/);
+    assert.fileContent(readme_path, /stop-foo-app-static/);
   });
 
   it('should copy scripts for starting server', () => {
-    assert.file('bin/start-server.js');
+    assert.file('packages/static-api/bin/start-server.js');
   });
 
   it('should copy script for stopping server', () => {
-    assert.file('bin/stop-server.js');
+    assert.file('packages/static-api/bin/stop-server.js');
   });
 
   it('should copy script for running server', () => {
-    assert.file('run-server.js');
+    assert.file('packages/static-api/run-server.js');
   });
 
   it('should copy package.json', () => {
-    assert.file('package.json');
+    assert.file('packages/static-api/package.json');
   });
 
   it('should update package.json with api name from input', () => {
-    assert.jsonFileContent('package.json', { name: `@springworks\/${api_name}-static` });
+    assert.jsonFileContent('packages/static-api/package.json', {
+      name: `@springworks\/${api_name}-static`,
+    });
   });
 
 });

--- a/test/static-api-test.js
+++ b/test/static-api-test.js
@@ -42,6 +42,14 @@ describe('test/static-api-test.js', () => {
     assert.file('packages/static-api/package.json');
   });
 
+  it('should copy script for generating API', () => {
+    assert.file('bin/generate-api-file.js');
+  });
+
+  it('should copy script for generating docs', () => {
+    assert.file('bin/generate-docs.js');
+  });
+
   it('should update package.json with api name from input', () => {
     assert.jsonFileContent('packages/static-api/package.json', {
       name: `@springworks\/${api_name}-static`,


### PR DESCRIPTION
# static-api

Generates files needed to package a "static API".
## Usage

Run generator from root of the API that needs a static representation.

```
$ yo springworks:static-api
```
## Result

Files and directories in a structure similar to:

```
|_ bin
|_ packages
  |_ static-api
```
