### PR TITLE
Add babel builder generator

### DIFF
--- a/generators/babel-builder/README.md
+++ b/generators/babel-builder/README.md
@@ -1,0 +1,11 @@
+# babel-builder
+
+Generates files and installs packages needed to configure a Babel project, that builds ES5 code before `npm publish`.
+
+## Usage
+
+Run generator from root of the project.
+
+```
+$ yo springworks:babel-builder
+```

--- a/generators/babel-builder/index.js
+++ b/generators/babel-builder/index.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const path = require('path');
+const generators = require('yeoman-generator');
+const package_updater = require('../../lib/package-updater');
+const dependency_installer = require('../../lib/dependency-installer');
+
+module.exports = generators.Base.extend({
+
+  constructor: function() {
+    generators.Base.apply(this, arguments);
+  },
+
+  forceConflictsToAvoidUnecessaryPrompts: function() {
+    this.conflicter.force = true;
+  },
+
+  initializing: function() {
+    const welcomeMessage = [
+      '\n',
+      'Configuring babel project...',
+      '\n',
+    ];
+    this.log(welcomeMessage.join(''));
+  },
+
+  writing: {
+
+    mochaConfig: function() {
+      this.copy('.babelrc', '.babelrc');
+    },
+
+    updatePackageFile: function() {
+      const pkg_path = path.join(process.cwd(), 'package.json');
+      const changes = {
+        scripts: {
+          build: 'rm -rf lib && babel src --out-dir lib',
+          prepublish: 'npm run build',
+        },
+      };
+      package_updater.updatePackageFile({
+        pkg_path: pkg_path,
+        changes: changes,
+        generator: this,
+      });
+    },
+
+  },
+
+  install: {
+
+    installDevDependencies: function() {
+      const dependencies = [
+        'babel-cli',
+        'babel-core',
+        'babel-plugin-transform-runtime',
+        'babel-plugin-transform-strict-mode',
+        'babel-preset-es2015-node4',
+      ];
+      dependency_installer.installDependencies({
+        generator: this,
+        package_names: dependencies,
+        options: {
+          saveDev: true,
+        },
+      });
+    },
+
+    installDependencies: function() {
+      const dependencies = [
+        'babel-runtime',
+      ];
+      dependency_installer.installDependencies({
+        generator: this,
+        package_names: dependencies,
+        options: {
+          save: true,
+        },
+      });
+    },
+
+  },
+
+
+});

--- a/generators/babel-builder/templates/.babelrc
+++ b/generators/babel-builder/templates/.babelrc
@@ -1,0 +1,9 @@
+{
+  "presets": [
+    "es2015-node4"
+  ],
+  "plugins": [
+    "transform-runtime",
+    "transform-strict-mode"
+  ]
+}

--- a/lib/dependency-installer.js
+++ b/lib/dependency-installer.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const assert = require('assert');
+
+module.exports = {
+
+  installDependencies(params) {
+    assert(params.package_names, 'package_named must be defined');
+    assert(params.generator, 'generator must be defined');
+
+    const options = params.options || {};
+
+    params.generator.npmInstall(params.package_names, options);
+  },
+
+};

--- a/lib/package-updater.js
+++ b/lib/package-updater.js
@@ -15,7 +15,7 @@ module.exports = {
     const result = _.merge(pkg, params.changes);
     const json = JSON.stringify(result, null, 2);
 
-    params.generator.write(params.pkg_path, json);
+    params.generator.write(params.pkg_path, `${json}\n`);
   },
 
 };

--- a/lib/package-updater.js
+++ b/lib/package-updater.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const _ = require('lodash');
+const assert = require('assert');
+const package_provider = require('../generators/testing/package-provider');
+
+module.exports = {
+
+  updatePackageFile(params) {
+    assert(params.pkg_path, 'pkg_path must be specified');
+    assert(params.changes, 'changes must be specified');
+    assert(params.generator, 'generator must be specified');
+
+    const pkg = package_provider.loadPackageFile(params.pkg_path);
+    const result = _.merge(pkg, params.changes);
+    const json = JSON.stringify(result, null, 2);
+
+    params.generator.write(params.pkg_path, json);
+  },
+
+};

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "1.1.1",
+    "lodash": "4.3.0",
     "yeoman-generator": "0.22.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,11 @@
   "scripts": {
     "test": "NODE_ENV=test istanbul cover _mocha -- --ui bdd --check-leaks --recursive --slow 200 --reporter spec test",
     "coveralls": "NODE_ENV=test istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- --recursive -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
-    "lint": "eslint .",
-    "build": "rm -rf lib && babel src --out-dir lib",
-    "prepublish": "npm run build"
+    "lint": "eslint ."
+  },
+  "engines": {
+    "node": ">=4",
+    "npm": ">=3"
   },
   "repository": {
     "type": "git",
@@ -26,18 +28,12 @@
   "author": "Springworks",
   "license": "MIT",
   "dependencies": {
-    "babel-runtime": "6.5.0",
     "chalk": "1.1.1",
     "lodash": "4.3.0",
     "yeoman-generator": "0.22.5"
   },
   "devDependencies": {
     "@springworks/test-harness": "1.2.4",
-    "babel-cli": "6.5.1",
-    "babel-core": "6.5.1",
-    "babel-plugin-transform-runtime": "6.5.0",
-    "babel-plugin-transform-strict-mode": "6.5.0",
-    "babel-preset-es2015-node4": "2.0.3",
     "chai": "3.5.0",
     "coveralls": "2.11.2",
     "eslint": "1.10.3",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "test": "NODE_ENV=test istanbul cover _mocha -- --ui bdd --check-leaks --recursive --slow 200 --reporter spec test",
     "coveralls": "NODE_ENV=test istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- --recursive -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "build": "rm -rf lib && babel src --out-dir lib",
+    "prepublish": "npm run build"
   },
   "repository": {
     "type": "git",
@@ -24,12 +26,18 @@
   "author": "Springworks",
   "license": "MIT",
   "dependencies": {
+    "babel-runtime": "6.5.0",
     "chalk": "1.1.1",
     "lodash": "4.3.0",
     "yeoman-generator": "0.22.5"
   },
   "devDependencies": {
     "@springworks/test-harness": "1.2.4",
+    "babel-cli": "6.5.1",
+    "babel-core": "6.5.1",
+    "babel-plugin-transform-runtime": "6.5.0",
+    "babel-plugin-transform-strict-mode": "6.5.0",
+    "babel-preset-es2015-node4": "2.0.3",
     "chai": "3.5.0",
     "coveralls": "2.11.2",
     "eslint": "1.10.3",

--- a/test/babel-builder-test.js
+++ b/test/babel-builder-test.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const path = require('path');
+const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+const package_updater = require('../lib/package-updater');
+const dependency_installer = require('../lib/dependency-installer');
+
+describe('test/babel-builder-test.js', () => {
+  let sinon_sandbox;
+
+  beforeEach(() => {
+    sinon_sandbox = sinon.sandbox.create();
+  });
+
+  beforeEach(() => {
+    sinon_sandbox.stub(package_updater, 'updatePackageFile').returns();
+  });
+
+  beforeEach(() => {
+    sinon_sandbox.stub(dependency_installer, 'installDependencies').returns();
+  });
+
+  beforeEach(done => {
+    helpers.run(path.join(__dirname, '..', 'generators', 'babel-builder'))
+        .withOptions({
+          'skip-install': true,
+        })
+        .withPrompts()
+        .on('end', done);
+  });
+
+  afterEach(() => {
+    sinon_sandbox.restore();
+  });
+
+  it('should copy .babelrc to root dir', () => {
+    assert.file('.babelrc');
+  });
+
+  it('should add build scripts to package.json', () => {
+    const call_args = package_updater.updatePackageFile.firstCall.args;
+    call_args[0].changes.should.eql({
+      scripts: {
+        build: 'rm -rf lib && babel src --out-dir lib',
+        prepublish: 'npm run build',
+      },
+    });
+  });
+
+  it('should install required babel dev dependencies', () => {
+    const call_args = dependency_installer.installDependencies.firstCall.args;
+    call_args[0].should.have.property('generator');
+    call_args[0].should.have.property('package_names', [
+      'babel-cli',
+      'babel-core',
+      'babel-plugin-transform-runtime',
+      'babel-plugin-transform-strict-mode',
+      'babel-preset-es2015-node4',
+    ]);
+    call_args[0].should.have.property('options', { saveDev: true });
+  });
+
+  it('should install required babel dependency', () => {
+    const call_args = dependency_installer.installDependencies.secondCall.args;
+    call_args[0].should.have.property('generator');
+    call_args[0].should.have.property('package_names', [
+      'babel-runtime',
+    ]);
+    call_args[0].should.have.property('options', { save: true });
+  });
+
+});

--- a/test/dependency-installer-test.js
+++ b/test/dependency-installer-test.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const installer = require('../lib/dependency-installer');
+
+describe('test/dependency-installer-test.js', () => {
+  let sinon_sandbox;
+
+  beforeEach(() => {
+    sinon_sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sinon_sandbox.restore();
+  });
+
+
+  describe('installDependencies', () => {
+
+    describe('with valid params', () => {
+      let params;
+      let mock_generator;
+
+      beforeEach(() => {
+        mock_generator = {
+          npmInstall: sinon_sandbox.stub(),
+        };
+      });
+
+      beforeEach(() => {
+        params = {
+          package_names: [
+            'lodash',
+            'fel',
+          ],
+          generator: mock_generator,
+          options: {
+            saveDev: true,
+          },
+        };
+      });
+
+      it('should invoke generator function to install provided dependencies', () => {
+        installer.installDependencies(params);
+        const call_args = mock_generator.npmInstall.firstCall.args;
+        call_args.should.eql([
+          params.package_names,
+          params.options,
+        ]);
+      });
+
+    });
+
+    describe('with invalid params', () => {
+
+      it('should throw', () => {
+        (() => installer.installDependencies({})).should.throw();
+      });
+
+    });
+
+  });
+
+});

--- a/test/package-updater-test.js
+++ b/test/package-updater-test.js
@@ -53,7 +53,7 @@ describe('test/package-updater-test.js', () => {
         const call_args = mock_generator.write.firstCall.args;
         call_args.should.eql([
           params.pkg_path,
-          result_as_json,
+          `${result_as_json}\n`,
         ]);
       });
 

--- a/test/package-updater-test.js
+++ b/test/package-updater-test.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const updater = require('../lib/package-updater');
+const package_provider = require('../generators/testing/package-provider');
+
+describe('test/package-updater-test.js', () => {
+  let sinon_sandbox;
+
+  beforeEach(() => {
+    sinon_sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sinon_sandbox.restore();
+  });
+
+  describe('updatePackageFile', () => {
+
+    describe('with valid params', () => {
+      let mock_generator;
+      let original_package;
+      let params;
+
+      beforeEach(() => {
+        original_package = {
+          baz: 'baz',
+        };
+        sinon_sandbox.stub(package_provider, 'loadPackageFile').returns(original_package);
+      });
+
+      beforeEach(() => {
+        mock_generator = {
+          write: sinon_sandbox.stub(),
+        };
+      });
+
+      beforeEach(() => {
+        params = {
+          pkg_path: '/dev/null',
+          changes: { foo: 'bar' },
+          generator: mock_generator,
+        };
+      });
+
+      it('should invoke write() with changes merged into package file', () => {
+        updater.updatePackageFile(params);
+
+        const result_as_json = JSON.stringify({
+          baz: 'baz',
+          foo: 'bar',
+        }, null, 2);
+
+        const call_args = mock_generator.write.firstCall.args;
+        call_args.should.eql([
+          params.pkg_path,
+          result_as_json,
+        ]);
+      });
+
+    });
+
+    describe('with invalid params', () => {
+
+      it('should throw', () => {
+        (() => updater.updatePackageFile({})).should.throw();
+      });
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
# babel-builder

Generates files and installs packages needed to configure a Babel project, that builds ES5 code before `npm publish`.
## Usage

Run generator from root of the project.

```
$ yo springworks:babel-builder
```
