### PR TITLE
Static API: Validate Swagger spec when generating file

### DIFF
--- a/generators/static-api/index.js
+++ b/generators/static-api/index.js
@@ -1,10 +1,8 @@
 'use strict';
 
 const generators = require('yeoman-generator');
+const dependency_installer = require('../../lib/dependency-installer');
 
-const api_dependencies = [
-  'swagger-md',
-];
 const static_api_dependencies = [
   '@springworks/static-api-server',
   'fixture-loader',
@@ -73,14 +71,25 @@ module.exports = generators.Base.extend({
 
   install: {
 
-    installDependencies: function() {
+    installDevDependencies: function() {
+      const dependencies = [
+        'swagger-md',
+        'swagger-tools',
+      ];
+      dependency_installer.installDependencies({
+        generator: this,
+        package_names: dependencies,
+        options: {
+          saveDev: true,
+        },
+      });
+    },
+
+    installStaticApiDependencies: function() {
       this.on('end', function() {
         if (!this.options['skip-install']) {
           const static_api_install_args = ['install', '--save'].concat(static_api_dependencies);
           this.spawnCommandSync('npm', static_api_install_args, { cwd: static_api_package_dir });
-
-          const api_install_args = ['install', '--save'].concat(api_dependencies);
-          this.spawnCommandSync('npm', api_install_args);
         }
       });
     },

--- a/generators/static-api/templates/bin/generate-api-file.js
+++ b/generators/static-api/templates/bin/generate-api-file.js
@@ -8,9 +8,68 @@
 
 const fs = require('fs');
 const path = require('path');
+const swagger_tools = require('swagger-tools');
 const api_spec = require('../resources/api/index');
 const target_filename = path.join(__dirname, '..', 'packages', 'static-api', 'api.json');
 
-const api_as_json = JSON.stringify(api_spec, null, 2) + '\n';
+const internals = {
 
-fs.writeFileSync(target_filename, api_as_json);
+  validateSwaggerSpec(swagger_api, callback) {
+    const swagger_spec = swagger_tools.specs.v2;
+    swagger_spec.validate(swagger_api, (err, result) => {
+      if (err) {
+        callback(err);
+        return;
+      }
+
+      if (!result) {
+        callback(null, null);
+        return;
+      }
+
+      if (!result.errors.length && !result.warnings.length) {
+        callback(null, null);
+        return;
+      }
+
+      if (result.errors.length > 0) {
+        console.log('Invalid Swagger spec:');
+        console.log('');
+        console.log('Errors');
+        console.log('------');
+        result.errors.forEach(function(err) {
+          console.log('#/' + err.path.join('/') + ': ' + err.message);
+        });
+        console.log('');
+      }
+
+      if (result.warnings.length > 0) {
+        console.log('Warnings');
+        console.log('--------');
+        result.warnings.forEach(function(warn) {
+          console.log('#/' + warn.path.join('/') + ': ' + warn.message);
+        });
+        console.log('');
+      }
+
+      const error = new Error('Swagger spec has issues');
+      callback(error, null);
+    });
+  },
+
+  writeSwaggerFile(swagger_api) {
+    const api_as_json = JSON.stringify(swagger_api, null, 2) + '\n';
+    fs.writeFileSync(target_filename, api_as_json);
+  },
+
+};
+
+internals.validateSwaggerSpec(api_spec, err => {
+  if (err) {
+    console.error(err);
+    process.exit(1);
+    return;
+  }
+
+  internals.writeSwaggerFile(api_spec);
+});

--- a/test/static-api-test.js
+++ b/test/static-api-test.js
@@ -3,11 +3,18 @@
 const path = require('path');
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');
+const dependency_installer = require('../lib/dependency-installer');
+const autorestoredSandbox = require('@springworks/test-harness/autorestored-sandbox');
 
 describe('test/static-api-test.js', () => {
+  const sinon_sandbox = autorestoredSandbox();
   const api_name = 'foo-app';
 
-  before(done => {
+  beforeEach(() => {
+    sinon_sandbox.stub(dependency_installer, 'installDependencies').returns();
+  });
+
+  beforeEach(done => {
     helpers.run(path.join(__dirname, '..', 'generators', 'static-api'))
         .withOptions({
           'skip-install': true,
@@ -57,6 +64,16 @@ describe('test/static-api-test.js', () => {
     assert.jsonFileContent('packages/static-api/package.json', {
       name: `@springworks\/${api_name}-static`,
     });
+  });
+
+  it('should install swagger-tools as dev dependency', () => {
+    const call_args = dependency_installer.installDependencies.firstCall.args;
+    call_args[0].should.have.property('generator');
+    call_args[0].should.have.property('package_names', [
+      'swagger-md',
+      'swagger-tools',
+    ]);
+    call_args[0].should.have.property('options', { saveDev: true });
   });
 
 });


### PR DESCRIPTION
Installs swagger-tools as dev dependency and runs validation when generating api.json.
