### PR TITLE
Update npm test scripts

### DIFF
--- a/generators/testing/index.js
+++ b/generators/testing/index.js
@@ -31,11 +31,15 @@ module.exports = generators.Base.extend({
     updatePackageFile: function() {
       const pkg_path = path.join(process.cwd(), 'package.json');
       const pkg = package_provider.loadPackageFile(pkg_path);
-      pkg.scripts.test = 'NODE_ENV=test istanbul cover _mocha';
-      pkg.scripts['test-unit'] = 'NODE_ENV=test istanbul cover _mocha -- $(find test/**/unit test/unit -name \'*.js\' 2>/dev/null)';
-      pkg.scripts['test-acceptance'] = 'NODE_ENV=test istanbul cover _mocha -- $(find test/**/acceptance test/acceptance -name \'*.js\' 2>/dev/null)';
-      pkg.scripts['test-component'] = 'NODE_ENV=test istanbul cover _mocha -- $(find test/**/component test/component -name \'*.js\' 2>/dev/null)';
-      this.write(pkg_path, JSON.stringify(pkg, null, 2));
+      const testing_scripts = {
+        test: 'NODE_ENV=test istanbul cover _mocha',
+        'test-no-cov': 'NODE_ENV=test mocha',
+        'test-acceptance': 'NODE_ENV=test istanbul cover _mocha -- --fgrep \'/acceptance/\'',
+        'test-component': 'NODE_ENV=test istanbul cover _mocha -- --fgrep \'/component/\'',
+        'test-unit': 'NODE_ENV=test istanbul cover _mocha -- --fgrep \'/unit/\'',
+      };
+      Object.assign(pkg.scripts, testing_scripts);
+      this.write(pkg_path, JSON.stringify(pkg, null, 2) + '\n');
     },
 
   },
@@ -52,6 +56,5 @@ module.exports = generators.Base.extend({
     },
 
   },
-
 
 });

--- a/package.json
+++ b/package.json
@@ -28,13 +28,11 @@
   "author": "Springworks",
   "license": "MIT",
   "dependencies": {
-    "chalk": "1.1.3",
     "lodash": "4.11.1",
     "yeoman-generator": "0.22.6"
   },
   "devDependencies": {
     "@springworks/test-harness": "1.3.0",
-    "chai": "3.5.0",
     "coveralls": "2.11.9",
     "eslint": "2.8.0",
     "eslint-config-springworks": "7.0.1",
@@ -44,8 +42,6 @@
     "eslint-plugin-springworks": "1.1.3",
     "istanbul": "0.4.3",
     "mocha": "2.2.1",
-    "mocha-lcov-reporter": "1.2.0",
-    "should": "8.3.1",
     "yeoman-assert": "2.2.0",
     "yeoman-test": "1.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -32,17 +32,17 @@
     "yeoman-generator": "0.22.6"
   },
   "devDependencies": {
-    "@springworks/test-harness": "1.3.0",
+    "@springworks/test-harness": "1.3.1",
     "coveralls": "2.11.9",
     "eslint": "2.8.0",
     "eslint-config-springworks": "7.0.1",
     "eslint-plugin-import": "1.5.0",
-    "eslint-plugin-mocha": "2.1.0",
+    "eslint-plugin-mocha": "2.2.0",
     "eslint-plugin-should-promised": "1.0.8",
     "eslint-plugin-springworks": "1.1.3",
     "istanbul": "0.4.3",
-    "mocha": "2.2.1",
-    "yeoman-assert": "2.2.0",
+    "mocha": "2.4.5",
+    "yeoman-assert": "2.2.1",
     "yeoman-test": "1.1.0"
   },
   "peerDependencies": {

--- a/test/testing-test.js
+++ b/test/testing-test.js
@@ -36,14 +36,14 @@ describe('test/testing-test.js', () => {
   });
 
   it('should add test scripts to package.json', () => {
-    assert.jsonFileContent('package.json', {
-      scripts: {
-        test: 'NODE_ENV=test istanbul cover _mocha',
-        'test-unit': 'NODE_ENV=test istanbul cover _mocha -- $(find test/**/unit test/unit -name \'*.js\' 2>/dev/null)',
-        'test-acceptance': 'NODE_ENV=test istanbul cover _mocha -- $(find test/**/acceptance test/acceptance -name \'*.js\' 2>/dev/null)',
-        'test-component': 'NODE_ENV=test istanbul cover _mocha -- $(find test/**/component test/component -name \'*.js\' 2>/dev/null)',
-      },
-    });
+    const expected_testing_scripts = {
+      test: 'NODE_ENV=test istanbul cover _mocha',
+      'test-no-cov': 'NODE_ENV=test mocha',
+      'test-acceptance': 'NODE_ENV=test istanbul cover _mocha -- --fgrep \'/acceptance/\'',
+      'test-component': 'NODE_ENV=test istanbul cover _mocha -- --fgrep \'/component/\'',
+      'test-unit': 'NODE_ENV=test istanbul cover _mocha -- --fgrep \'/unit/\'',
+    };
+    assert.jsonFileContent('package.json', { scripts: expected_testing_scripts });
   });
 
 });


### PR DESCRIPTION
- The unit/component/acceptance test scripts use `--fgrep` to match the test type.
- Add `test-no-cov` that runs all tests without coverage.
