### PR TITLE
fix(babel-builder): ensure all files are copied when building with babel

### DIFF
--- a/generators/babel-builder/index.js
+++ b/generators/babel-builder/index.js
@@ -34,7 +34,7 @@ module.exports = generators.Base.extend({
       const pkg_path = path.join(process.cwd(), 'package.json');
       const changes = {
         scripts: {
-          build: 'rm -rf build && babel src --out-dir build',
+          build: 'rm -rf build && babel src --out-dir build --copy-files',
           prepublish: 'yarn run build',
         },
       };

--- a/test/babel-builder-test.js
+++ b/test/babel-builder-test.js
@@ -42,7 +42,7 @@ describe('test/babel-builder-test.js', () => {
     const call_args = package_updater.updatePackageFile.firstCall.args;
     call_args[0].changes.should.eql({
       scripts: {
-        build: 'rm -rf build && babel src --out-dir build',
+        build: 'rm -rf build && babel src --out-dir build --copy-files',
         prepublish: 'yarn run build',
       },
     });


### PR DESCRIPTION
Would otherwise exclude .json files and other.