### PR TITLE
chore: remove version from package.json

### DIFF
--- a/generators/static-api/templates/_package.json
+++ b/generators/static-api/templates/_package.json
@@ -1,6 +1,5 @@
 {
   "name": "@springworks/<%=appname%>-static",
-  "version": "0.0.1",
   "description": "Static implementation of the API",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
we don't really care about version in static API package. When publishing from TeamCity to the NPM registry it will be set to `10.0.<TeamCity build number>`